### PR TITLE
chore: update go-release-workflow to v0.4.6-1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@d5b30f148d2f6fb207c58aee61fab4d3a3021421 # v0.4.5
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@feat-limit-permissions-and-repositories
     with:
       homebrew: true
       go-version: 1.21.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,11 +6,17 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@feat-limit-permissions-and-repositories
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@222ceba72b0138163dcb8b6cd0ed44f061705ccc # v0.4.6-1
     with:
       homebrew: true
       go-version: 1.21.4
       aqua_version: v2.21.0
+      app_token_repositories: >-
+        [
+          "${{github.event.repository.name}}",
+          "homebrew-${{github.event.repository.name}}",
+          "scoop-bucket"
+        ]
     secrets:
       gh_app_id: ${{secrets.APP_ID}}
       gh_app_private_key: ${{secrets.APP_PRIVATE_KEY}}


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/go-release-workflow/pull/61