### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,5 +14,8 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: read
+      id-token: write

--- a/.github/workflows/wc-test.yaml
+++ b/.github/workflows/wc-test.yaml
@@ -1,12 +1,18 @@
 ---
 name: test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -16,6 +22,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -42,4 +46,8 @@ jobs:
   test:
     uses: ./.github/workflows/wc-test.yaml
     needs: path-filter
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard into the Go CI workflows.

## Changes

- `.github/workflows/release.yaml`: added a `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the `go-release-workflow` call (the ref was already pinned at `@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0`).
- `.github/workflows/wc-test.yaml`: declared the required `TAKUMI_GUARD_BOT_ID` secret on `workflow_call`; added the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` step immediately after `actions/setup-go` and before `aqua-installer`/the Go module-downloading steps (`golangci-lint run`, `go test`, `go install`); and set the `test` job `permissions:` to `contents: read` + `id-token: write` (was `{}`).
- `.github/workflows/workflow_call_test.yaml`: declared the required `TAKUMI_GUARD_BOT_ID` secret on `workflow_call`; passed it down to the `wc-test.yaml` call and added `id-token: write` (plus `contents: read`) to that `test` job.
- `.github/workflows/test.yaml`: passed `TAKUMI_GUARD_BOT_ID` to the `workflow_call_test.yaml` call and added `id-token: write` to that `test` job, completing the secret/OIDC chain from the `pull_request` entrypoint down to the Go test job.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)